### PR TITLE
Fix/Feat: 여러가지 에러, 페이지네이션, 라우터연결

### DIFF
--- a/src/atoms/manageAtom.ts
+++ b/src/atoms/manageAtom.ts
@@ -9,3 +9,8 @@ export const manageListAtom = atom({
   key: 'manageListAtom',
   default: [],
 });
+
+export const manageListLength = atom({
+  key: 'manageListLength',
+  default: 0,
+});

--- a/src/atoms/pageNumAtom.ts
+++ b/src/atoms/pageNumAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const pageNum = atom({
+  key: 'pageNum',
+  default: 1,
+});

--- a/src/atoms/pageOffsetAtom.ts
+++ b/src/atoms/pageOffsetAtom.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const PageOffset = atom({
-  key: 'PageOffset',
-  default: 1,
-});

--- a/src/components/Main/PageNation/index.tsx
+++ b/src/components/Main/PageNation/index.tsx
@@ -32,7 +32,7 @@ const PageNation = ({ productsLength }: Props) => {
     if (clickPageNum % 5 === 1 || clickPageNum % 5 > 1) {
       setCurrentPageArray(sliceArray[Math.floor(clickPageNum / 5)]);
     }
-  }, [totalPages]);
+  }, [clickPageNum, totalPages]);
 
   if (totalPages) {
     return (

--- a/src/components/Main/PageNation/index.tsx
+++ b/src/components/Main/PageNation/index.tsx
@@ -4,17 +4,17 @@ import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import Arrow from '../../../assets/Arrow.svg';
-import { PageOffset } from '../../../atoms/pageOffsetAtom';
+import { pageNum } from '../../../atoms/pageNumAtom';
 
 interface Props {
-  products: productCategoryProps[];
+  productsLength?: number;
 }
 
-const PageNation = ({ products }: Props) => {
-  const totalPages = Math.ceil(products?.length / 3);
+const PageNation = ({ productsLength }: Props) => {
+  const totalPages = Math.ceil(productsLength! / 3);
   const numbersArray = new Array(totalPages).fill(0);
-  const [currentPage, setCurrentPage] = useRecoilState(PageOffset);
   const [currentPageArray, setCurrentPageArray] = useState([0]);
+  const [clickPageNum, setClickPageNum] = useRecoilState(pageNum);
 
   // 페이지네이션 버튼에서 5까지만 보여주기 위한 cut 함수
   const sliceArrayFunc = (totalPages: number) => {
@@ -25,29 +25,29 @@ const PageNation = ({ products }: Props) => {
   };
 
   useEffect(() => {
-    const sliceArray = sliceArrayFunc(totalPages);
+    const sliceArray = sliceArrayFunc(totalPages / 3);
     setCurrentPageArray(sliceArray[0]);
 
     // 다음 페이지 배열로 넘어감
-    if (currentPage % 5 === 1 || currentPage % 5 > 1) {
-      setCurrentPageArray(sliceArray[Math.floor(currentPage / 5)]);
+    if (clickPageNum % 5 === 1 || clickPageNum % 5 > 1) {
+      setCurrentPageArray(sliceArray[Math.floor(clickPageNum / 5)]);
     }
-  }, [currentPage, totalPages]);
+  }, [totalPages]);
 
   if (totalPages) {
     return (
       <PageBtnWrap>
         <PrevBtnArrow
-          onClick={() => setCurrentPage((prev) => prev - 1)}
-          disabled={currentPage === 1}
+          onClick={() => setClickPageNum((prev) => prev - 1)}
+          disabled={clickPageNum === 1}
         >
           <img src={Arrow} />
         </PrevBtnArrow>
         <PageNumWrap>
           {currentPageArray?.map((idx) => (
             <div key={idx}>
-              <div onClick={() => setCurrentPage(idx + 1)}>
-                {currentPage === idx + 1 ? (
+              <div onClick={() => setClickPageNum(idx + 1)}>
+                {clickPageNum === idx + 1 ? (
                   <PageNumActive>{idx + 1}</PageNumActive>
                 ) : (
                   <PageNumNonActive>{idx + 1}</PageNumNonActive>
@@ -57,8 +57,8 @@ const PageNation = ({ products }: Props) => {
           ))}
         </PageNumWrap>
         <NextBtnArrow
-          onClick={() => setCurrentPage((prev) => prev + 1)}
-          disabled={currentPage === totalPages}
+          onClick={() => setClickPageNum((prev) => prev + 1)}
+          disabled={clickPageNum === totalPages}
         >
           <img src={Arrow} />
         </NextBtnArrow>

--- a/src/components/Main/ProductContainer/ItemBox.tsx
+++ b/src/components/Main/ProductContainer/ItemBox.tsx
@@ -8,6 +8,7 @@ import PhotoBox from '../../common/PhotoBox';
 interface ItemBoxProps {
   items?: productCategoryProps;
   isClicked?: boolean;
+  productsId?: string;
 }
 
 const ItemBox = ({ items, isClicked }: ItemBoxProps) => {
@@ -16,11 +17,17 @@ const ItemBox = ({ items, isClicked }: ItemBoxProps) => {
     navigate('/Registration', { state: items?.id });
   };
 
+  // TODO room페이지 컴포넌트로 넘어갈 때 정보 넘겨줘야함
+  // TODO 내가 만든 방인지 다른 사람 방인지 검증 후, 보여주는 room 화면 다르도록 해야함
+  const handleMoveRoom = () => {
+    navigate('/room');
+  };
+
   return (
     <>
       <ItemBoxWrap>
         <PhotoBox src={items?.imageUrl} />
-        <div style={{ marginLeft: '22px' }}>
+        <div style={{ marginLeft: '22px' }} onClick={handleMoveRoom}>
           <ProductInfoListWrap>
             {/* <li>
               제목 : <p>{items?.productTitle}</p>

--- a/src/components/Main/ProductContainer/index.tsx
+++ b/src/components/Main/ProductContainer/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
-import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
-import { PageOffset } from '../../../atoms/pageOffsetAtom';
+import { pageNum } from '../../../atoms/pageNumAtom';
 
 import ItemBox from './ItemBox';
 
@@ -12,11 +12,8 @@ interface Props {
   isClicked?: boolean;
 }
 
-// TODO 페이지네이션 로직 전부 수정하기
-// 페이지네이션 3개까지만 보일 수 있도록 offset을 활용해 slice
 const ProductContainer = ({ products, isClicked }: Props) => {
-  const offset = (useRecoilValue(PageOffset) - 1) * 3;
-  const resetOffset = useResetRecoilState(PageOffset);
+  const resetOffset = useResetRecoilState(pageNum);
 
   // 다시 offset 0부터 보일 수 있도록 추가
   useEffect(() => {
@@ -25,7 +22,7 @@ const ProductContainer = ({ products, isClicked }: Props) => {
 
   return (
     <ProductBoxWrap>
-      {products?.slice(offset, offset + 3).map((item) => (
+      {products.map((item) => (
         <ItemBox
           key={item.productTitle}
           items={item}

--- a/src/components/Main/ProductContainer/index.tsx
+++ b/src/components/Main/ProductContainer/index.tsx
@@ -12,6 +12,7 @@ interface Props {
   isClicked?: boolean;
 }
 
+// TODO 페이지네이션 로직 전부 수정하기
 // 페이지네이션 3개까지만 보일 수 있도록 offset을 활용해 slice
 const ProductContainer = ({ products, isClicked }: Props) => {
   const offset = (useRecoilValue(PageOffset) - 1) * 3;
@@ -25,7 +26,12 @@ const ProductContainer = ({ products, isClicked }: Props) => {
   return (
     <ProductBoxWrap>
       {products?.slice(offset, offset + 3).map((item) => (
-        <ItemBox key={item.productTitle} items={item} isClicked={isClicked} />
+        <ItemBox
+          key={item.productTitle}
+          items={item}
+          isClicked={isClicked}
+          productsId={item.id}
+        />
       ))}
     </ProductBoxWrap>
   );

--- a/src/components/common/NavigationBar/index.tsx
+++ b/src/components/common/NavigationBar/index.tsx
@@ -5,7 +5,11 @@ import styled from 'styled-components';
 
 import LionMarket from '../../../assets/LionMarket.svg';
 import { categoryAtom } from '../../../atoms/categoryAtom';
-import { manageBtnAtom, manageListAtom } from '../../../atoms/manageAtom';
+import {
+  manageBtnAtom,
+  manageListAtom,
+  manageListLength,
+} from '../../../atoms/manageAtom';
 import { instanceAPI } from '../../../utils/constant';
 import SearchInput from '../Search';
 import { showToastMessage } from '../Toast';
@@ -13,6 +17,7 @@ import { showToastMessage } from '../Toast';
 const NavigationBar = () => {
   const handleClickManageBtn = useSetRecoilState(manageBtnAtom);
   const handleSetUserProducts = useSetRecoilState(manageListAtom);
+  const handleSetUserProductsLength = useSetRecoilState(manageListLength);
 
   const handleClickMainBtn = useResetRecoilState(manageBtnAtom);
   const returnCategory = useResetRecoilState(categoryAtom);
@@ -25,8 +30,9 @@ const NavigationBar = () => {
   const handleClickManage = () => {
     handleClickManageBtn(true);
 
-    instanceAPI.get(`/products/user-products`).then((res) => {
+    return instanceAPI.get(`products/user-products`).then((res) => {
       if (res.status === 200) {
+        handleSetUserProductsLength(res.data.meta.itemCount);
         handleSetUserProducts(res.data.data);
       }
     });

--- a/src/components/common/NavigationBar/index.tsx
+++ b/src/components/common/NavigationBar/index.tsx
@@ -89,6 +89,7 @@ const NaviBarWrap = styled.div`
   margin: 0 auto;
   padding: 0 50px;
   background-color: ${({ theme }) => theme.colors.NAVY};
+  z-index: 10;
 `;
 
 const LogoWrap = styled.div`

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { categoryAtom } from '../../atoms/categoryAtom';
 import { manageBtnAtom, manageListAtom } from '../../atoms/manageAtom';
+import { pageNum } from '../../atoms/pageNumAtom';
 import CategoryListBox from '../../components/Category';
 import PageNation from '../../components/Main/PageNation';
 import ProductContainer from '../../components/Main/ProductContainer';
@@ -16,26 +17,34 @@ const MainPage = () => {
   const isClickManageBtn = useRecoilValue(manageBtnAtom);
   const userProducts = useRecoilValue(manageListAtom);
   const currentCategory = useRecoilValue(categoryAtom);
+  const currentPageNum = useRecoilValue(pageNum);
+
+  const [totalPageLength, setTotalPageLength] = useState(0);
   const [products, setProducts] = useState([]);
   const productList = isClickManageBtn ? userProducts : products;
 
-  const getProduct = (currentCategory: string) => {
+  const getProduct = (currentCategory: string, currentPageNum: number) => {
     instanceAPI
       .get(
         `products`,
         currentCategory
           ? {
-              params: { category: currentCategory },
+              params: { category: currentCategory, page: currentPageNum },
             }
-          : undefined,
+          : {
+              params: { page: currentPageNum },
+            },
       )
-      .then((res) => setProducts(res.data.data))
+      .then((res) => {
+        setTotalPageLength(res.data.meta.itemCount);
+        setProducts(res.data.data);
+      })
       .catch((err) => console.log(err));
   };
 
   useEffect(() => {
-    getProduct(currentCategory);
-  }, [currentCategory]);
+    getProduct(currentCategory, currentPageNum);
+  }, [currentCategory, currentPageNum]);
 
   return (
     <MainPageWrap>
@@ -44,7 +53,7 @@ const MainPage = () => {
       </CategoryAside>
       <MainContentBox>
         <ProductContainer products={productList} isClicked={isClickManageBtn} />
-        <PageNation products={productList} />
+        <PageNation productsLength={totalPageLength} />
       </MainContentBox>
     </MainPageWrap>
   );

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -4,18 +4,21 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import { categoryAtom } from '../../atoms/categoryAtom';
-import { manageBtnAtom, manageListAtom } from '../../atoms/manageAtom';
+import {
+  manageBtnAtom,
+  manageListAtom,
+  manageListLength,
+} from '../../atoms/manageAtom';
 import { pageNum } from '../../atoms/pageNumAtom';
 import CategoryListBox from '../../components/Category';
 import PageNation from '../../components/Main/PageNation';
 import ProductContainer from '../../components/Main/ProductContainer';
 import { instanceAPI } from '../../utils/constant';
 
-// TODO ProductContainer/SearchContainer/MyRoomContainer 상황에 맞게 렌더링되도록 구현해보기
-// 넘어가는 products의 값이 다르도록?
 const MainPage = () => {
   const isClickManageBtn = useRecoilValue(manageBtnAtom);
   const userProducts = useRecoilValue(manageListAtom);
+  const userProductsLength = useRecoilValue(manageListLength);
   const currentCategory = useRecoilValue(categoryAtom);
   const currentPageNum = useRecoilValue(pageNum);
 
@@ -53,7 +56,11 @@ const MainPage = () => {
       </CategoryAside>
       <MainContentBox>
         <ProductContainer products={productList} isClicked={isClickManageBtn} />
-        <PageNation productsLength={totalPageLength} />
+        <PageNation
+          productsLength={
+            isClickManageBtn ? userProductsLength : totalPageLength
+          }
+        />
       </MainContentBox>
     </MainPageWrap>
   );

--- a/src/pages/Registration/index.tsx
+++ b/src/pages/Registration/index.tsx
@@ -94,7 +94,10 @@ const Registration = () => {
     if (registItemInfo) {
       instanceAPI
         .post(`products `, registItemInfo)
-        .then((res) => console.log(res))
+        .then((res) => {
+          console.log(res);
+          navigate('/');
+        })
         .catch((err) => console.log(err));
     } else {
       console.log('실행이 안되었습니다');

--- a/src/pages/Registration/index.tsx
+++ b/src/pages/Registration/index.tsx
@@ -143,7 +143,7 @@ const Registration = () => {
           imageUpload(imgFile);
         }}
       >
-        <TitleBox>
+        <TitleBox onClick={() => navigate('/')}>
           <img src={Arrow} />
           <Title>제목</Title>
         </TitleBox>
@@ -231,6 +231,7 @@ const Title = styled.p`
 `;
 
 const BreakLine = styled.div`
+  width: 700px;
   height: 3px;
   margin-top: 32px;
   background-color: ${({ theme }) => theme.colors.WHITE};
@@ -239,7 +240,7 @@ const BreakLine = styled.div`
 const ItemBox = styled.div`
   display: flex;
   height: 265px;
-  margin-top: 53px;
+  margin-top: 53px; // TODO 여기 margin이랑 BrakeLine이랑 안 맞아서 라인이 안 보이네요! 수정필요할 것 같습니다!
   border-radius: 15px;
   background-color: #1e1e1e; //얜 또 따로놈
 `;

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -11,10 +11,22 @@ export const API = process.env.REACT_APP_API_URL;
 // instance api
 export const instanceAPI = axios.create({
   baseURL: `${API}`,
-  headers: {
-    Authorization: `Bearer ${getCookie()}`,
-  },
 });
+
+// 리프레시 토큰 없어서 우선 request만 정의
+instanceAPI.interceptors.request.use(
+  function (config) {
+    const accessToken = getCookie();
+
+    if (accessToken) {
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  function (error) {
+    return Promise.reject(error);
+  },
+);
 
 // 아이디, 이메일, 번호, 패스워드 정규식
 export const ID_REGEXP = /^[a-zA-Z0-9_-]{5,20}$/;


### PR DESCRIPTION
## ⛳️ 작업 내용

- [x] instanceAPI 코드 수정 (401 에러 이제 안뜹니다!)
- [x] 상품 클릭 ➡️ /room 페이지 이동
- [x] 방 관리 톱니바퀴 클릭 ➡️ /Regrigation 페이지 이동
- [x] 메인페이지 상품리스트와 네비게이션 바 겹침 해결
- [x] (GET) /products에서 받아온 itemCount로 페이지네이션 구현

## 🌱 PR 포인트
참고사항
- 등록이나 수정할 때 품명부분이 placeholder가 아니어서 입력할 때 불편한 게 있는 것 같습니다..!
- 등록페이지에서 css에 BreakLine과 ItemBox의 margin 싱크가 안 맞아서 BreakLine 하얀 줄이 안 보이는 것 같습니다! 중요사항은 아니지만 나중에 프로젝트 완성하고 조금씩 손 보는 과정에서 수정이 필요할 것 같습니다~~~!
- 등록할 때 버튼을 2번눌러야 등록이 가능하던데(처음 눌렀을 땐 500error) 뭐가 문제인지 모르겠네요 ㅜㅜ


## 📸 스크린샷
|라우터연결|등록방관리|
|:--:|:--:|
|![라우터연결](https://user-images.githubusercontent.com/81777778/232517194-5474d2a6-4439-4525-a66e-8cf41b3be308.gif)|![등록방관리](https://user-images.githubusercontent.com/81777778/232517315-0023cac6-1d68-4380-9397-0c25c9aa1dcd.gif)|

|페이지네이션|
|:--:|
|![페이지네이션](https://user-images.githubusercontent.com/81777778/232517433-8b59a8d3-b03a-4acf-958f-d26918bab410.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->