### PR TITLE
검색 기능 붙이기

### DIFF
--- a/src/atoms/searchItemAtom.ts
+++ b/src/atoms/searchItemAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const searchItemAtom = atom({
+  key: 'searchItemAtom',
+  default: '',
+});

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -2,6 +2,7 @@ import { useRecoilState, useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { categoryAtom } from '../../atoms/categoryAtom';
+import { searchItemAtom } from '../../atoms/searchItemAtom';
 import { categoryItemList } from '../../utils/mock';
 
 // TODO atom selector 활용해봐도 괜찮을듯,, => 필요없어서 없앱니다!
@@ -34,6 +35,8 @@ import { categoryItemList } from '../../utils/mock';
 
 const CategoryListBox = () => {
   const [filter, setFilter] = useRecoilState(categoryAtom);
+  const [searchItem] = useRecoilState(searchItemAtom);
+  const resetSearchItem = useResetRecoilState(searchItemAtom);
   const resetFilter = useResetRecoilState(categoryAtom);
 
   return (
@@ -48,6 +51,9 @@ const CategoryListBox = () => {
             if (item.name === '기타') {
               resetFilter();
               return;
+            }
+            if (searchItem) {
+              resetSearchItem();
             }
             setFilter(item.name);
           }}

--- a/src/components/common/Search/index.tsx
+++ b/src/components/common/Search/index.tsx
@@ -1,15 +1,35 @@
+import { useState } from 'react';
+
+import { useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import SearchIcon from '../../../assets/SearchIcon.svg';
+import { searchItemAtom } from '../../../atoms/searchItemAtom';
 
-const SearchInput = () => (
-  <div style={{ position: 'relative' }}>
-    <SearchWrap placeholder="제품을 검색해보세요!" />
-    <SearchIconContainer>
-      <img src={SearchIcon} />
-    </SearchIconContainer>
-  </div>
-);
+const SearchInput = () => {
+  const setSearchAtom = useSetRecoilState(searchItemAtom);
+  const [isSearched, setIsSearched] = useState('');
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <SearchWrap
+        placeholder="제품을 검색해보세요!"
+        onChange={(e) => {
+          setIsSearched(e.target.value);
+        }}
+        value={isSearched}
+      />
+      <SearchIconContainer
+        onClick={() => {
+          setSearchAtom(isSearched);
+          setIsSearched('');
+        }}
+      >
+        <img src={SearchIcon} />
+      </SearchIconContainer>
+    </div>
+  );
+};
 
 const SearchWrap = styled.input`
   width: 400px;

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { categoryAtom } from '../../atoms/categoryAtom';
@@ -10,6 +10,7 @@ import {
   manageListLength,
 } from '../../atoms/manageAtom';
 import { pageNum } from '../../atoms/pageNumAtom';
+import { searchItemAtom } from '../../atoms/searchItemAtom';
 import CategoryListBox from '../../components/Category';
 import PageNation from '../../components/Main/PageNation';
 import ProductContainer from '../../components/Main/ProductContainer';
@@ -21,16 +22,27 @@ const MainPage = () => {
   const userProductsLength = useRecoilValue(manageListLength);
   const currentCategory = useRecoilValue(categoryAtom);
   const currentPageNum = useRecoilValue(pageNum);
+  const currentSearchItem = useRecoilValue(searchItemAtom);
+
+  const resetCategory = useResetRecoilState(categoryAtom);
 
   const [totalPageLength, setTotalPageLength] = useState(0);
   const [products, setProducts] = useState([]);
   const productList = isClickManageBtn ? userProducts : products;
 
-  const getProduct = (currentCategory: string, currentPageNum: number) => {
+  const getProduct = (
+    currentCategory: string,
+    currentPageNum: number,
+    currentSearchItem: string,
+  ) => {
     instanceAPI
       .get(
         `products`,
-        currentCategory
+        currentSearchItem
+          ? {
+              params: { page: 1, search: currentSearchItem },
+            }
+          : currentCategory
           ? {
               params: { category: currentCategory, page: currentPageNum },
             }
@@ -41,13 +53,16 @@ const MainPage = () => {
       .then((res) => {
         setTotalPageLength(res.data.meta.itemCount);
         setProducts(res.data.data);
+        if (currentSearchItem) {
+          resetCategory();
+        }
       })
       .catch((err) => console.log(err));
   };
 
   useEffect(() => {
-    getProduct(currentCategory, currentPageNum);
-  }, [currentCategory, currentPageNum]);
+    getProduct(currentCategory, currentPageNum, currentSearchItem);
+  }, [currentCategory, currentPageNum, currentSearchItem]);
 
   return (
     <MainPageWrap>


### PR DESCRIPTION
## ⛳️ 작업 내용

검색 기능 


## 🌱 PR 포인트

1. 검색할 경우 검색을 최우선 -> 카테고리 비활성화
2. 검색한 경우에도 카테고리를 사용할 수 있어야됨, 카테고리 선택 시 검색란 초기화
3. 라우터 분리하기 싫어서 검색란있는지 먼저 보고 그 다음에 카테고리 활성화 되어있는지 체크했습니다
4. 페이지를 먼저 선택하고 (4페이지에서) 검색란을 할 경우에 파라미터가 같이 넘어가서, 검색을 할경우는 무조건 1 페이지 기준으로 검색하고,만약에 검색 결과가 3개가 넘어가면 그 때 컨디션을 하나 더 추가해서 컨트롤 하면 될 것 같습니다. 그 때 가서 코드가 너무 지저분 할 것 같으면 라우터 분리할게요! 파라미터 조건이 여러가지 케이스인 라우터의 경우는 정말로 api 따로 분리해야 될 것 같기도합니다 
5. 영상 찍으면서 체크 했는데, 검색하고나서 기타 카테고리를 누르면 전체 목록으로 안넘어가네요... 이건 한번 체크해보겠습니다... 디폴트가 달라서 그런가?

https://user-images.githubusercontent.com/81761524/233130059-cab95e71-e84f-462e-9644-01a5ceb0b9c0.mov



<!-- 알아야 하는 중요한 사항이 있다면 여기에 적어 공유해주세요 -->

## 📸 스크린샷
|스크린샷|

|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->