### PR TITLE
Feat: 페이지 접근 제어, 상품 없을 시 컴포넌트 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
+import { useCookies } from 'react-cookie';
 import { Route, Routes } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import './App.css';
 
 import 'react-toastify/dist/ReactToastify.css';
+import AccessRightRoute from './components/Auth/AccessRightRoute';
 import { Toast } from './components/common/Toast';
 import Layout from './components/layout';
 import SignIn from './pages/Auth/SignIn';
@@ -14,6 +16,8 @@ import GlobalStyle from './styles/GlobalStyle';
 import Theme from './styles/Theme';
 
 function App() {
+  const [token, ,] = useCookies(['userToken']);
+
   return (
     <div className="App">
       <ThemeProvider theme={Theme}>
@@ -21,10 +25,26 @@ function App() {
         <Layout>
           <Routes>
             <Route path="/" element={<MainPage />} />
-            <Route path="/room" element={<RoomPage />} />
+            <Route
+              path="/room"
+              element={
+                <AccessRightRoute
+                  token={token.userToken}
+                  component={<RoomPage />}
+                />
+              }
+            />
             <Route path="/sign-in" element={<SignIn />} />
             <Route path="/sign-up" element={<SignUp />} />
-            <Route path="/Registration" element={<Registration />} />
+            <Route
+              path="/Registration"
+              element={
+                <AccessRightRoute
+                  token={token.userToken}
+                  component={<Registration />}
+                />
+              }
+            />
           </Routes>
         </Layout>
         <Toast />

--- a/src/components/Auth/AccessRightRoute.tsx
+++ b/src/components/Auth/AccessRightRoute.tsx
@@ -1,0 +1,11 @@
+import GuideBox from '../common/GuideBox';
+
+interface Props {
+  token: string;
+  component: React.ReactElement;
+}
+
+const AccessRightRoute = ({ token, component }: Props) =>
+  token ? component : <GuideBox msg="로그인 후 이용해주세요!" />;
+
+export default AccessRightRoute;

--- a/src/components/Main/ProductContainer/ItemBox.tsx
+++ b/src/components/Main/ProductContainer/ItemBox.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 
 import Delete from '../../../assets/Delete.svg';
 import Setting from '../../../assets/Setting.svg';
+import { getCookie } from '../../../utils/constant';
 import PhotoBox from '../../common/PhotoBox';
+import { showToastMessage } from '../../common/Toast';
 
 interface ItemBoxProps {
   items?: productCategoryProps;
@@ -12,6 +14,7 @@ interface ItemBoxProps {
 }
 
 const ItemBox = ({ items, isClicked }: ItemBoxProps) => {
+  const accessToken = getCookie();
   const navigate = useNavigate();
   const handleMoveEditPage = () => {
     navigate('/Registration', { state: items?.id });
@@ -20,7 +23,9 @@ const ItemBox = ({ items, isClicked }: ItemBoxProps) => {
   // TODO room페이지 컴포넌트로 넘어갈 때 정보 넘겨줘야함
   // TODO 내가 만든 방인지 다른 사람 방인지 검증 후, 보여주는 room 화면 다르도록 해야함
   const handleMoveRoom = () => {
-    navigate('/room');
+    accessToken
+      ? navigate('/room')
+      : showToastMessage('로그인 후 이용해주세요!');
   };
 
   return (

--- a/src/components/Main/ProductContainer/index.tsx
+++ b/src/components/Main/ProductContainer/index.tsx
@@ -4,6 +4,7 @@ import { useResetRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import { pageNum } from '../../../atoms/pageNumAtom';
+import GuideBox from '../../common/GuideBox';
 
 import ItemBox from './ItemBox';
 
@@ -22,14 +23,20 @@ const ProductContainer = ({ products, isClicked }: Props) => {
 
   return (
     <ProductBoxWrap>
-      {products.map((item) => (
-        <ItemBox
-          key={item.productTitle}
-          items={item}
-          isClicked={isClicked}
-          productsId={item.id}
-        />
-      ))}
+      {products.length === 0 ? (
+        <GuideBox msg="상품이 없어요!" />
+      ) : (
+        <>
+          {products.map((item) => (
+            <ItemBox
+              key={item.productTitle}
+              items={item}
+              isClicked={isClicked}
+              productsId={item.id}
+            />
+          ))}
+        </>
+      )}
     </ProductBoxWrap>
   );
 };

--- a/src/components/common/GuideBox/index.tsx
+++ b/src/components/common/GuideBox/index.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+import LionMarket from '../../../assets/LionMarket.svg';
+
+interface Props {
+  msg?: string;
+}
+
+const GuideBox = ({ msg }: Props) => (
+  <GuideBoxWrap>
+    <GuideBoxImg src={LionMarket} />
+    <GuideBoxFont>{msg}</GuideBoxFont>
+  </GuideBoxWrap>
+);
+
+const GuideBoxWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 15%;
+  color: ${({ theme }) => theme.colors.WHITE};
+  ${({ theme }) => theme.fonts.B_POINT_22};
+`;
+
+const GuideBoxImg = styled.img`
+  fill: ${({ theme }) => theme.colors.WHITE};
+`;
+
+const GuideBoxFont = styled.p`
+  padding: 20px;
+`;
+
+export default GuideBox;


### PR DESCRIPTION
## ⛳️ 작업 내용

간단한 요소 두 개 정도 추가했습니다!
- 로그인 여부에 따라 접근할 수 있는 페이지 나누기
- 메인이든 카테고리든 상품이 없을 시 보여줄 멘트 추가

## 🌱 PR 포인트

<!-- 알아야 하는 중요한 사항이 있다면 여기에 적어 공유해주세요 -->

## 📸 스크린샷
|접근제어|상품없을 때|
|:--:|:--:|
|![접근제어](https://user-images.githubusercontent.com/81777778/233852843-72ceeca1-2f48-42e0-8b6a-0a904634911d.gif)|![상품없을때](https://user-images.githubusercontent.com/81777778/233852865-258085bd-5ef3-4f0e-9cfb-bb82e51e2dc9.gif)| 

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->