### PR TITLE
feat: 방 이탈 시 소켓 연결 끊기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,18 +22,9 @@ function App() {
     <div className="App">
       <ThemeProvider theme={Theme}>
         <GlobalStyle />
-        <Layout>
-          <Routes>
+        <Routes>
+          <Route element={<Layout />}>
             <Route path="/" element={<MainPage />} />
-            <Route
-              path="/room"
-              element={
-                <AccessRightRoute
-                  token={token.userToken}
-                  component={<RoomPage />}
-                />
-              }
-            />
             <Route path="/sign-in" element={<SignIn />} />
             <Route path="/sign-up" element={<SignUp />} />
             <Route
@@ -45,8 +36,17 @@ function App() {
                 />
               }
             />
-          </Routes>
-        </Layout>
+          </Route>
+          <Route
+            path="/room"
+            element={
+              <AccessRightRoute
+                token={token.userToken}
+                component={<RoomPage />}
+              />
+            }
+          />
+        </Routes>
         <Toast />
       </ThemeProvider>
     </div>

--- a/src/components/common/NavigationBar/index.tsx
+++ b/src/components/common/NavigationBar/index.tsx
@@ -14,8 +14,11 @@ import { instanceAPI } from '../../../utils/constant';
 import SearchInput from '../Search';
 import { showToastMessage } from '../Toast';
 
-const NavigationBar = () => {
-  // const roomSocket = socket('1');
+interface roomSocketProps {
+  roomSocket?: any | null;
+}
+
+const NavigationBar = ({ roomSocket }: roomSocketProps) => {
   const handleClickManageBtn = useSetRecoilState(manageBtnAtom);
   const handleSetUserProducts = useSetRecoilState(manageListAtom);
   //관리자에 관련된 데이터들을 전역으로 관리하려고 하셨던 스페셜한 이유가 혹시 있으실까요?
@@ -26,7 +29,7 @@ const NavigationBar = () => {
   const returnCategory = useResetRecoilState(categoryAtom);
 
   const handleReturn = () => {
-    // roomSocket.disconnect();
+    roomSocket.disconnect();
     handleClickMainBtn();
     returnCategory();
   };

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,3 +1,4 @@
+import { Outlet } from 'react-router-dom';
 import styled from 'styled-components';
 
 import NavigationBar from '../common/NavigationBar';
@@ -9,7 +10,7 @@ interface layoutProps {
 const Layout = ({ children }: layoutProps) => (
   <LayoutContainer>
     <NavigationBar />
-    <LayoutContents>{children}</LayoutContents>
+    <LayoutContents>{children || <Outlet />}</LayoutContents>
   </LayoutContainer>
 );
 

--- a/src/pages/RoomPage/index.tsx
+++ b/src/pages/RoomPage/index.tsx
@@ -72,17 +72,24 @@ const RoomPage = () => {
             setChat((prevChat) => [...prevChat, newChat]);
           });
 
+          window.addEventListener('popstate', handlePopstate);
+
           return () => {
             roomSocket.off('alert');
             roomSocket.off('userList');
             roomSocket.off('message');
 
+            window.removeEventListener('popstate', handlePopstate);
             roomSocket.disconnect();
           };
         })
         .catch(() => showToastMessage('유효하지 않은 상품id입니다.'));
     }
   }, []);
+
+  const handlePopstate = () => {
+    roomSocket.disconnect();
+  };
 
   const handleChangeMsg = (message: string) => {
     setSendMsg(message);

--- a/src/pages/RoomPage/index.tsx
+++ b/src/pages/RoomPage/index.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable autofix/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// eslint 잠시 주석처리 해두었습니다. 해결후에 다 지울예정
 import { useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -9,6 +6,7 @@ import styled from 'styled-components';
 import Arrow from '../../assets/Arrow.svg';
 import Keyboard from '../../assets/Keyboard.svg';
 import { BasicButton } from '../../components/common/BasicButton';
+import NavigationBar from '../../components/common/NavigationBar';
 import { showToastMessage } from '../../components/common/Toast';
 import { instanceAPI } from '../../utils/constant';
 import { socket } from '../../utils/socket';
@@ -104,6 +102,7 @@ const RoomPage = () => {
 
   return (
     <Container>
+      <NavigationBar roomSocket={roomSocket} />
       <TradeContainer>
         <ItemInfoBox>
           <ImgBox>
@@ -185,6 +184,7 @@ const RoomPage = () => {
     </Container>
   );
 };
+
 const ArrowImg = styled.img`
   position: relative;
   /* CurrentUserBox 기준으로 계산 */
@@ -196,12 +196,10 @@ const ArrowImg = styled.img`
 
 const Container = styled.div`
   display: flex;
-  justify-content: space-between;
-  margin: auto;
-  width: 90%;
+  justify-content: space-evenly;
+  width: 100%;
   height: 854px;
-  /* height: 90vh; //이건 한번 보고 */
-  margin-top: 33px;
+  margin-top: 100px;
 `;
 
 const TradeContainer = styled.div`
@@ -211,7 +209,7 @@ const TradeContainer = styled.div`
   justify-content: space-between;
   width: 945px;
   height: 778px;
-  margin: auto;
+  margin: auto 20px;
 `;
 
 const Image = styled.img`
@@ -222,7 +220,6 @@ const Image = styled.img`
 
 const ItemInfoBox = styled.div`
   display: flex;
-  flex-direction: row;
   align-items: center;
   width: 945px;
   height: 224px;
@@ -259,7 +256,7 @@ const UserContainer = styled.div`
   flex-direction: column;
   width: 320px;
   height: 854px;
-  margin: auto;
+  margin: 38px auto;
   border-radius: 15px;
   background-color: ${({ theme }) => theme.colors.NAVY};
 `;


### PR DESCRIPTION
## ⛳️ 작업 내용

- [x] 웹 브라우저 뒤로 가기 클릭 시 연결 해제
- [x] 사자마켓 로고 클릭 시 연결 해제
- [x] 연결 해제 될 시 userId [object Object]로 받아와지는 현상 해결 > 서버 수정 완료

## 🌱 PR 포인트

네비게이션 바를 큰 레이아웃 컴포넌트에 포함시켜놓고 컴포넌트를 children으로 보여주다보니,
네비바에 뭔가를 전달해야 할 땐 무조건 전역을 사용해야해서 로고 클릭했을 때 나가는 걸 어떻게 구현해야할지가 좀 어려웠습니다.

소켓 값을 전역으로 넘길수도 없었고 id를 전역으로 넘겨 네비게이션 바에서 해당 id를 넣은 소켓을 또 불러오자니 같은 id 유저가 2명 접속한 듯이 생성이 되길래, 아예 App.tsx에서 roomPage를 레이아웃에서 빼버리고 직접 네비게이션 컴포넌트를 불러오는 걸 선택했습니다.

roomPage에서 생성한 소켓값을 props로 네비게이션에 넘긴 후, 로고에 disconnect()를 하니 정상적으로 작동하는 것을 확인했습니다! 👍🏻

## 📸 스크린샷
|스크린샷|
|:--:|
|![퇴장알림](https://github.com/mju-Sharper/under-draw/assets/81777778/57f14379-82d4-45a3-b912-4007b1dc7292)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->