### PR TITLE
Fix: 등록이미지 깨짐 수정 / 채팅 UI 보완

### DIFF
--- a/src/pages/Registration/index.tsx
+++ b/src/pages/Registration/index.tsx
@@ -285,10 +285,10 @@ const PlusButton = styled.button`
 `;
 
 const ImgPreView = styled.img`
-  /* width: 100%;
-  height: 100%; 일단 지워놓고 */
+  width: 100%;
+  height: 100%;
   border-radius: 15px;
-  object-fit: cover;
+  object-fit: scale-down;
 `;
 
 const ImgUpload = styled.label`

--- a/src/pages/RoomPage/index.tsx
+++ b/src/pages/RoomPage/index.tsx
@@ -19,6 +19,7 @@ const CONTROL_ARRAY = ['START', 'NEXT', 'STOP', 'RESET'];
 type ChatMsg = {
   username: string;
   message: string;
+  admin?: boolean;
 };
 
 type User = {
@@ -62,10 +63,11 @@ const RoomPage = () => {
           roomSocket.on('userList', (list: socketUserList) =>
             setUsers(list.connectedUsers),
           );
-          roomSocket.on('message', (data: socketChatMsg) => {
+          roomSocket.on('chat', (data: socketChatMsg) => {
             const newChat: ChatMsg = {
               username: data.userInfo.userId,
               message: data.message.message,
+              admin: data.userInfo.isAdmin,
             };
             setChat((prevChat) => [...prevChat, newChat]);
           });
@@ -94,7 +96,7 @@ const RoomPage = () => {
   };
 
   const handleSendMsg = () => {
-    roomSocket.emit('message', {
+    roomSocket.emit('chat', {
       message: sendMsg,
     });
     setSendMsg('');
@@ -138,7 +140,17 @@ const RoomPage = () => {
             <ChatContainer>
               {chat.map((msg, idx) => (
                 <ChatContent key={idx}>
-                  {msg.username}: {msg.message}
+                  <>
+                    {msg.admin ? (
+                      <div style={{ display: 'flex' }}>
+                        <AdminChat>{msg.username}</AdminChat>: {msg.message}
+                      </div>
+                    ) : (
+                      <>
+                        {msg.username}: {msg.message}
+                      </>
+                    )}
+                  </>
                 </ChatContent>
               ))}
             </ChatContainer>
@@ -390,4 +402,9 @@ const BettingText = styled.p`
   ${({ theme }) => theme.fonts.B_POINT_20}
   color: ${({ theme }) => theme.colors.WHITE};
 `;
+
+const AdminChat = styled.p`
+  color: #62b9b9;
+`;
+
 export default RoomPage;


### PR DESCRIPTION
## ⛳️ 작업 내용

등록페이지에서 등록하는 이미지 깨짐 현상을 수정했습니다.
추가로 경매 채팅에서 admin이 메세지를 보내주는 경우, 한 번에 알아볼 수 있도록 admin의 닉네임 색상만 다르게 나오도록 UI를 보완했습니다.

## 🌱 PR 포인트

<!-- 알아야 하는 중요한 사항이 있다면 여기에 적어 공유해주세요 -->

## 📸 스크린샷
|이미지 등록 문제사진|수정 사진|
|:--:|:--:|
|![스크린샷 2023-05-14 오후 6 44 17](https://github.com/mju-Sharper/under-draw/assets/81777778/35b3bc19-be4c-493d-ba10-db7aa44df1f5)|![스크린샷 2023-05-14 오후 6 44 28](https://github.com/mju-Sharper/under-draw/assets/81777778/7c09f738-a32a-4266-9342-d34fa3e1e695)|

|어드민 구별하는 채팅창|
|:--:|
|<img width="476" alt="스크린샷 2023-05-14 오후 6 49 16" src="https://github.com/mju-Sharper/under-draw/assets/81777778/130be076-06d5-48f0-878a-28ffa945acfb">|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->